### PR TITLE
7 ondryice navbar skeleton

### DIFF
--- a/src/assets/components/Page.js
+++ b/src/assets/components/Page.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { notFoundError } from '../utils/Errors';
+import { Navbar } from './margins/Navbar';
 
 export class Page extends React.Component {
     constructor(props) {
@@ -20,6 +21,7 @@ export class Page extends React.Component {
     render() {
         return (
             <div className='Page'>
+                <Navbar currentPage={this.state.content} />
                 {this.getContent()}
             </div>
         );

--- a/src/assets/components/margins/Navbar.js
+++ b/src/assets/components/margins/Navbar.js
@@ -12,7 +12,7 @@ export class Navbar extends React.Component {
     render() {
         return (
             <div className='navbar'>
-                
+                <p>TODO: navbar content</p>
             </div>
         );
     }

--- a/src/assets/components/margins/Navbar.js
+++ b/src/assets/components/margins/Navbar.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export class Navbar extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+
+        };
+    }
+
+    render() {
+        return (
+            <div className='navbar'>
+                
+            </div>
+        );
+    }
+}

--- a/src/assets/components/margins/Navbar.js
+++ b/src/assets/components/margins/Navbar.js
@@ -5,15 +5,40 @@ export class Navbar extends React.Component {
         super(props);
 
         this.state = {
-
+            currentPage: this.props.currentPage
         };
+
+        this.sections = [
+            {   name:'home-page',
+                content: 'Home',
+                classes: 'navbar-btn-home',
+                onClick: null
+            }
+        ];
     }
 
     render() {
         return (
             <div className='navbar'>
                 <p>TODO: navbar content</p>
+                {this.renderButtons()}
             </div>
         );
+    }
+
+    renderButtons() {
+        return this.sections.map(
+            (section, index) => {
+                return (
+                    <div
+                        key={'nb-'+index}
+                        className={section.classes}
+                        onClick={section.onClick}
+                    >
+                        <p>{section.content}</p>
+                    </div>
+                );
+            }
+        )
     }
 }


### PR DESCRIPTION
added the skeleton component for the navbar

will use the prop `currentPage` to highlight the navbar button associated with the current page
the `currentPage` navbar button should use `className='currentPage'` or something similar, with CSS that changes the cursor to `default` and has no `onHover` behavior, to make clear that clicking the button will do nothing